### PR TITLE
Several fixes

### DIFF
--- a/spring-cloud-dataflow-metrics-collector-dependencies/pom.xml
+++ b/spring-cloud-dataflow-metrics-collector-dependencies/pom.xml
@@ -27,6 +27,11 @@
 				<artifactId>caffeine</artifactId>
 				<version>2.4.0</version>
 			</dependency>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-starter-hateoas</artifactId>
+				<version>1.5.2.RELEASE</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/spring-cloud-starter-dataflow-metrics-collector/pom.xml
+++ b/spring-cloud-starter-dataflow-metrics-collector/pom.xml
@@ -25,6 +25,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-hateoas</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricsCollectorConfiguration.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricsCollectorConfiguration.java
@@ -24,7 +24,6 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.dataflow.metrics.collector.endpoint.RootEndpoint;
-import org.springframework.cloud.dataflow.metrics.collector.support.ApplicationMetricsBindingPostProcessor;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.dataflow.metrics.collector.endpoint.MetricsCollectorEndpoint;
 import org.springframework.cloud.dataflow.metrics.collector.model.ApplicationMetrics;
@@ -76,4 +75,8 @@ public class MetricsCollectorConfiguration {
 		return new MetricsCollectorEndpoint(rawCache);
 	}
 
+	@Bean
+	public RootEndpoint rootEndpoint(EntityLinks entityLinks){
+		return new RootEndpoint(entityLinks);
+	}
 }

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricsCollectorConfiguration.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricsCollectorConfiguration.java
@@ -23,6 +23,8 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.dataflow.metrics.collector.endpoint.RootEndpoint;
+import org.springframework.cloud.dataflow.metrics.collector.support.ApplicationMetricsBindingPostProcessor;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.dataflow.metrics.collector.endpoint.MetricsCollectorEndpoint;
 import org.springframework.cloud.dataflow.metrics.collector.model.ApplicationMetrics;
@@ -30,6 +32,7 @@ import org.springframework.cloud.dataflow.metrics.collector.support.MetricJsonSe
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.hateoas.EntityLinks;
 
 
 /**
@@ -50,10 +53,10 @@ public class MetricsCollectorConfiguration {
 	}
 
 	/**
-	 * This cache holds "raw" instances from messages arriving over the sink. It's lifecycle controls the normalized cache by
-	 * evicting entries on the normalized cache as they get evicted here.
+	 * Provides the underlying storage for received messages. Eviction can be controlled via
+	 * property spring.cloud.dataflow.metrics.collector.evictionTimeout
 	 *
-	 * @return
+	 * @return A {@link Cache} with configured eviction policy
 	 * @throws Exception
 	 */
 	@Bean
@@ -62,8 +65,6 @@ public class MetricsCollectorConfiguration {
 				.expireAfterWrite(properties.getEvictionTimeout(), TimeUnit.SECONDS)
 				.build();
 	}
-
-
 
 	@Bean
 	public MetricsAggregator metricsAggregator(Cache<String,ApplicationMetrics> rawCache){
@@ -74,4 +75,5 @@ public class MetricsCollectorConfiguration {
 	public MetricsCollectorEndpoint metricsCollectorEndpoint(Cache<String,ApplicationMetrics> rawCache){
 		return new MetricsCollectorEndpoint(rawCache);
 	}
+
 }

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/MetricsCollectorEndpoint.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/MetricsCollectorEndpoint.java
@@ -59,7 +59,7 @@ public class MetricsCollectorEndpoint {
 		this.rawCache = rawCache;
 	}
 
-	@RequestMapping(produces = { MediaType.APPLICATION_JSON_VALUE })
+	@RequestMapping(produces = { "application/vnd.spring.cloud.dataflow.collector.v1.hal+json" })
 	public ResponseEntity<PagedResources<StreamMetrics>> fetchMetrics(
 			@RequestParam(value = "name", defaultValue = "") String name) {
 		Collection<StreamMetrics> entries = new LinkedList<>();
@@ -117,18 +117,13 @@ public class MetricsCollectorEndpoint {
 				: root;
 		Application application = new Application(
 				(String) applicationMetrics.getProperties().get(ApplicationMetrics.APPLICATION_NAME));
-		Double incomeRate = YANUtils
-				.cast(findMetric(applicationMetrics.getMetrics(), MetricsAggregator.INPUT_METRIC_NAME).getValue(),
-						Double.class)
-				.orElse(0.0);
-		Double outgoingRate = YANUtils
-				.cast(findMetric(applicationMetrics.getMetrics(), MetricsAggregator.OUTPUT_METRIC_NAME).getValue(),
-						Double.class)
-				.orElse(0.0);
+
+		Double incomeRate = YANUtils.toDouble(findMetric(applicationMetrics.getMetrics(), MetricsAggregator.INPUT_METRIC_NAME).getValue());
+
+		Double outgoingRate = YANUtils.toDouble(findMetric(applicationMetrics.getMetrics(), MetricsAggregator.OUTPUT_METRIC_NAME).getValue());
 
 		Integer instanceIndex = YANUtils
-				.cast(applicationMetrics.getProperties().get(ApplicationMetrics.INSTANCE_INDEX), Integer.class)
-				.orElse(0);
+				.toInteger(applicationMetrics.getProperties().get(ApplicationMetrics.INSTANCE_INDEX));
 
 		Instance instance = new Instance(
 				applicationMetrics.getProperties().get(ApplicationMetrics.APPLICATION_GUID).toString(), incomeRate,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/MetricsCollectorEndpoint.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/MetricsCollectorEndpoint.java
@@ -34,6 +34,7 @@ import org.springframework.cloud.dataflow.metrics.collector.model.StreamMetrics;
 import org.springframework.cloud.dataflow.metrics.collector.utils.YANUtils;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.Link;
+import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.http.HttpStatus;
@@ -59,7 +60,7 @@ public class MetricsCollectorEndpoint {
 		this.rawCache = rawCache;
 	}
 
-	@RequestMapping(produces = { "application/vnd.spring.cloud.dataflow.collector.v1.hal+json" })
+	@RequestMapping(produces = MediaTypes.HAL_JSON_VALUE)
 	public ResponseEntity<PagedResources<StreamMetrics>> fetchMetrics(
 			@RequestParam(value = "name", defaultValue = "") String name) {
 		Collection<StreamMetrics> entries = new LinkedList<>();

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/MetricsCollectorEndpoint.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/MetricsCollectorEndpoint.java
@@ -69,11 +69,10 @@ public class MetricsCollectorEndpoint {
 			StreamMetrics streamMetrics = null;
 			for(ApplicationMetrics app : applicationMetrics){
 				streamMetrics = convert(app, streamMetrics);
-				if(streamMetrics!= null){
-					entries.add(streamMetrics);
-				}
 			}
-
+			if(streamMetrics!= null){
+				entries.add(streamMetrics);
+			}
 		}else{
 			Set<String> names = StringUtils.commaDelimitedListToSet(name);
 			for(String streamName : names){

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/RootEndpoint.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/RootEndpoint.java
@@ -1,0 +1,32 @@
+package org.springframework.cloud.dataflow.metrics.collector.endpoint;
+
+
+import org.springframework.cloud.dataflow.metrics.collector.model.RootResource;
+import org.springframework.cloud.dataflow.metrics.collector.model.StreamMetrics;
+import org.springframework.hateoas.EntityLinks;
+import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.hateoas.Link;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Vinicius Carvalho
+ */
+@RestController
+@ExposesResourceFor(RootEndpoint.class)
+public class RootEndpoint {
+
+	private final EntityLinks entityLinks;
+
+	public RootEndpoint(EntityLinks entityLinks) {
+		this.entityLinks = entityLinks;
+	}
+
+	@RequestMapping("/")
+	public RootResource info(){
+		String streamTemplated = entityLinks.linkToCollectionResource(StreamMetrics.class).getHref() + "?{name}";
+		RootResource rootResource = new RootResource();
+		rootResource.add(new Link(streamTemplated).withRel("/collector/metrics/streams"));
+		return rootResource;
+	}
+}

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/RootEndpoint.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/RootEndpoint.java
@@ -6,6 +6,7 @@ import org.springframework.cloud.dataflow.metrics.collector.model.StreamMetrics;
 import org.springframework.hateoas.EntityLinks;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.Link;
+import org.springframework.hateoas.MediaTypes;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,7 +25,7 @@ public class RootEndpoint {
 		this.entityLinks = entityLinks;
 	}
 
-	@RequestMapping(method = RequestMethod.GET, produces = { "application/vnd.spring.cloud.dataflow.collector.v1.hal+json" })
+	@RequestMapping(method = RequestMethod.GET, produces = MediaTypes.HAL_JSON_VALUE)
 	public RootResource info(){
 		String streamTemplated = entityLinks.linkToCollectionResource(StreamMetrics.class).getHref() + "?{name}";
 		RootResource rootResource = new RootResource();

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/RootEndpoint.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/RootEndpoint.java
@@ -7,6 +7,7 @@ import org.springframework.hateoas.EntityLinks;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.Link;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @ExposesResourceFor(RootEndpoint.class)
+@RequestMapping("/")
 public class RootEndpoint {
 
 	private final EntityLinks entityLinks;
@@ -22,7 +24,7 @@ public class RootEndpoint {
 		this.entityLinks = entityLinks;
 	}
 
-	@RequestMapping("/")
+	@RequestMapping(method = RequestMethod.GET, produces = { "application/vnd.spring.cloud.dataflow.collector.v1.hal+json" })
 	public RootResource info(){
 		String streamTemplated = entityLinks.linkToCollectionResource(StreamMetrics.class).getHref() + "?{name}";
 		RootResource rootResource = new RootResource();

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Application.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Application.java
@@ -25,14 +25,16 @@ import com.fasterxml.jackson.annotation.JsonCreator;
  * @author Vinicius Carvalho
  */
 public class Application {
+
 	private String name;
+
+	private List<Instance> instances = new LinkedList<>();
+
 
 	@JsonCreator
 	public Application(String name) {
 		this.name = name;
 	}
-
-	private List<Instance> instances = new LinkedList<>();
 
 	public String getName() {
 		return name;

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/ApplicationMetrics.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/ApplicationMetrics.java
@@ -37,7 +37,7 @@ public class ApplicationMetrics {
 	public static final String SERVER_NAME = "spring.cloud.dataflow.server.name";
 	public static final String APPLICATION_TYPE = "spring.cloud.dataflow.stream.app.type";
 	public static final String APPLICATION_GUID = "spring.cloud.application.guid";
-	public static final String INSTANCE_INDEX = "spring.cloud.stream.instanceIndex";
+	public static final String INSTANCE_INDEX = "spring.application.index";
 	public static final String APPLICATION_METRICS_JSON = "application/vnd.spring.cloud.stream.metrics.v1+json";
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Instance.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Instance.java
@@ -29,9 +29,15 @@ import org.springframework.cloud.dataflow.metrics.collector.utils.DeltaNumberHol
 public class Instance {
 
 	private String guid;
+
 	private Integer index;
+
+	private String key;
+
 	private Map<String,Object> properties;
+
 	private DeltaNumberHolder incomingRate;
+
 	private DeltaNumberHolder outgoingRate;
 
 	@JsonCreator
@@ -79,9 +85,18 @@ public class Instance {
 		return outgoingRate.getCurrentValue();
 	}
 
+	public String getKey() {
+		return key;
+	}
+
+	public void setKey(String key) {
+		this.key = key;
+	}
+
 	public void updateOutgoingRate(Double value){
 		this.outgoingRate.update(value);
 	}
+
 	public void updateIncomingRate(Double value){
 		this.incomingRate.update(value);
 	}

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/RootResource.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/RootResource.java
@@ -1,0 +1,9 @@
+package org.springframework.cloud.dataflow.metrics.collector.model;
+
+import org.springframework.hateoas.ResourceSupport;
+
+/**
+ * @author Vinicius Carvalho
+ */
+public class RootResource extends ResourceSupport {
+}

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/StreamMetrics.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/StreamMetrics.java
@@ -21,12 +21,14 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import org.springframework.hateoas.ResourceSupport;
+
 /**
  * @author Vinicius Carvalho
  */
-public class Stream {
+public class StreamMetrics{
 	@JsonCreator
-	public Stream(String name) {
+	public StreamMetrics(String name) {
 		this.name = name;
 	}
 

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/support/ApplicationMetricsBindingPostProcessor.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/support/ApplicationMetricsBindingPostProcessor.java
@@ -1,0 +1,24 @@
+package org.springframework.cloud.dataflow.metrics.collector.support;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+/**
+ * @author Vinicius Carvalho
+ * Sets the spring.cloud.stream.bindings.input.destination to default value of 'metrics', it can be overriden via environment properties abstraction.
+ */
+public class ApplicationMetricsBindingPostProcessor implements EnvironmentPostProcessor{
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+		Map<String, Object> propertiesToAdd = new HashMap<>();
+		propertiesToAdd.put("spring.cloud.stream.bindings.input.destination",
+				"metrics");
+		environment.getPropertySources()
+				.addLast(new MapPropertySource("collectorDefaultProperties", propertiesToAdd));
+	}
+}

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/utils/YANUtils.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/utils/YANUtils.java
@@ -18,14 +18,44 @@ package org.springframework.cloud.dataflow.metrics.collector.utils;
 
 import java.util.Optional;
 
+import org.springframework.util.StringUtils;
+
 /**
  * Yet Another Utils class
  * @author Vinicius Carvalho
  */
 public class YANUtils {
 	public static <S, T> Optional<T> cast(S candidate, Class<T> targetClass) {
-		return targetClass.isInstance(candidate)
-				? Optional.of(targetClass.cast(candidate))
-				: Optional.empty();
+		return targetClass.isInstance(candidate) ? Optional.of(targetClass.cast(candidate)) : Optional.empty();
+	}
+
+	public static Double toDouble(Object value){
+		Double result = 0.0;
+
+		if(value == null){
+			return result;
+		}
+		String stringVal = value.toString();
+		try{
+			result = Double.valueOf(stringVal);
+		}catch (NumberFormatException e){
+		}
+
+		return result;
+	}
+
+	public static Integer toInteger(Object value){
+		Integer result = 0;
+
+		if(value == null){
+			return result;
+		}
+		String stringVal = value.toString();
+		try{
+			result = Integer.valueOf(stringVal);
+		}catch (NumberFormatException e){
+		}
+		
+		return result;
 	}
 }

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.env.EnvironmentPostProcessor=\
+  org.springframework.cloud.dataflow.metrics.collector.support.ApplicationMetricsBindingPostProcessor

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/resources/application.properties
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.cloud.stream.bindings.input.destination=metrics

--- a/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/MetricsAggregatorTests.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/MetricsAggregatorTests.java
@@ -127,6 +127,7 @@ public class MetricsAggregatorTests extends BaseCacheTests {
 		application = streamMetrics.getApplications().get(0);
 		Assert.assertNotNull(streamMetrics);
 		Assert.assertEquals("http", application.getName());
+		Assert.assertEquals(1, endpoint.fetchMetrics("").getBody().getContent().size());
 		Assert.assertEquals(2, application.getInstances().size());
 
 	}
@@ -200,10 +201,12 @@ public class MetricsAggregatorTests extends BaseCacheTests {
 		MetricsCollectorEndpoint endpoint = new MetricsCollectorEndpoint(rawCache);
 
 		ApplicationMetrics app = createMetrics("httpIngest", "http", "foo", 0, 1.0, 0.0);
+		ApplicationMetrics app1 = createMetrics("httpIngest", "http", "foobar", 1, 1.0, 0.0);
 		ApplicationMetrics app2 = createMetrics("woodchuck", "time", "bar", 0, 1.0, 0.0);
 		ApplicationMetrics app3 = createMetrics("twitter", "twitterstream", "bar", 0, 1.0, 0.0);
 
 		aggregator.receive(app);
+		aggregator.receive(app1);
 		aggregator.receive(app2);
 		aggregator.receive(app3);
 

--- a/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/MetricsAggregatorTests.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/MetricsAggregatorTests.java
@@ -129,7 +129,11 @@ public class MetricsAggregatorTests extends BaseCacheTests {
 		Assert.assertEquals("http", application.getName());
 		Assert.assertEquals(1, endpoint.fetchMetrics("").getBody().getContent().size());
 		Assert.assertEquals(2, application.getInstances().size());
-
+		Instance i1 = application.getInstances().get(0);
+		Assert.assertNotNull(i1);
+		Instance i2 = application.getInstances().get(1);
+		Assert.assertNotNull(i2);
+		Assert.assertNotEquals(i1.getIndex(),i2.getIndex());
 	}
 
 	@Test
@@ -229,6 +233,7 @@ public class MetricsAggregatorTests extends BaseCacheTests {
 		Assert.assertEquals(0, endpoint.fetchMetrics("httpIngest;woodchuck").getBody().getContent().size());
 	}
 
+
 	private ApplicationMetrics createMetrics(String streamName, String applicationName, String appGuid, Integer index,
 			Double incomingRate, Double outgoingRate) {
 
@@ -238,7 +243,7 @@ public class MetricsAggregatorTests extends BaseCacheTests {
 		properties.put(ApplicationMetrics.STREAM_NAME, streamName);
 		properties.put(ApplicationMetrics.APPLICATION_NAME, applicationName);
 		properties.put(ApplicationMetrics.APPLICATION_GUID, appGuid);
-		properties.put(ApplicationMetrics.INSTANCE_INDEX, index);
+		properties.put(ApplicationMetrics.INSTANCE_INDEX, index.toString());
 		applicationMetrics.getMetrics().add(new Metric<>(MetricsAggregator.INPUT_METRIC_NAME, incomingRate));
 		applicationMetrics.getMetrics().add(new Metric<>(MetricsAggregator.OUTPUT_METRIC_NAME, outgoingRate));
 		properties.put(MetricsAggregator.INPUT_METRIC_NAME, incomingRate);

--- a/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/MetricsAggregatorTests.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/MetricsAggregatorTests.java
@@ -212,6 +212,22 @@ public class MetricsAggregatorTests extends BaseCacheTests {
 
 		Assert.assertEquals(2, endpoint.fetchMetrics("httpIngest,woodchuck").getBody().getContent().size());
 	}
+	@Test
+	public void filterUsingInvalidDelimiter() throws Exception {
+		Cache<String, ApplicationMetrics> rawCache = Caffeine.newBuilder().build();
+		MetricsAggregator aggregator = new MetricsAggregator(rawCache);
+		MetricsCollectorEndpoint endpoint = new MetricsCollectorEndpoint(rawCache);
+
+		ApplicationMetrics app = createMetrics("httpIngest", "http", "foo", 0, 1.0, 0.0);
+		ApplicationMetrics app2 = createMetrics("woodchuck", "time", "bar", 0, 1.0, 0.0);
+		ApplicationMetrics app3 = createMetrics("twitter", "twitterstream", "bar", 0, 1.0, 0.0);
+
+		aggregator.receive(app);
+		aggregator.receive(app2);
+		aggregator.receive(app3);
+
+		Assert.assertEquals(0, endpoint.fetchMetrics("httpIngest;woodchuck").getBody().getContent().size());
+	}
 
 	private ApplicationMetrics createMetrics(String streamName, String applicationName, String appGuid, Integer index,
 			Double incomingRate, Double outgoingRate) {

--- a/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/MetricsAggregatorTests.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/MetricsAggregatorTests.java
@@ -20,9 +20,13 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 
+import javax.servlet.http.HttpServletRequest;
+
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.boot.actuate.metrics.Metric;
@@ -30,12 +34,27 @@ import org.springframework.cloud.dataflow.metrics.collector.endpoint.MetricsColl
 import org.springframework.cloud.dataflow.metrics.collector.model.Application;
 import org.springframework.cloud.dataflow.metrics.collector.model.ApplicationMetrics;
 import org.springframework.cloud.dataflow.metrics.collector.model.Instance;
-import org.springframework.cloud.dataflow.metrics.collector.model.Stream;
+import org.springframework.cloud.dataflow.metrics.collector.model.StreamMetrics;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 /**
  * @author Vinicius Carvalho
  */
 public class MetricsAggregatorTests extends BaseCacheTests {
+
+	@Before
+	public void setup() {
+		HttpServletRequest mockRequest = new MockHttpServletRequest();
+		ServletRequestAttributes servletRequestAttributes = new ServletRequestAttributes(mockRequest);
+		RequestContextHolder.setRequestAttributes(servletRequestAttributes);
+	}
+
+	@After
+	public void teardown() {
+		RequestContextHolder.resetRequestAttributes();
+	}
 
 	@Test
 	public void includeOneMetric() throws Exception {
@@ -46,11 +65,12 @@ public class MetricsAggregatorTests extends BaseCacheTests {
 		aggregator.receive(app);
 
 		Assert.assertEquals(1, rawCache.estimatedSize());
-		Stream stream = endpoint.fetchMetrics("").getBody().iterator().next();
-		Application application = stream.getApplications().get(0);
-		Assert.assertNotNull(stream);
+		StreamMetrics streamMetrics = endpoint.fetchMetrics("").getBody().iterator().next();
+		Application application = streamMetrics.getApplications().get(0);
+		Assert.assertNotNull(streamMetrics);
 		Assert.assertEquals("http", application.getName());
 		Instance instance = application.getInstances().get(0);
+		Assert.assertEquals(app.getName(),instance.getKey());
 		Assert.assertEquals("foo", instance.getGuid());
 	}
 
@@ -63,9 +83,9 @@ public class MetricsAggregatorTests extends BaseCacheTests {
 		aggregator.receive(app);
 
 		Assert.assertEquals(1, rawCache.estimatedSize());
-		Stream stream = endpoint.fetchMetrics("").getBody().iterator().next();
-		Application application = stream.getApplications().get(0);
-		Assert.assertNotNull(stream);
+		StreamMetrics streamMetrics = endpoint.fetchMetrics("").getBody().iterator().next();
+		Application application = streamMetrics.getApplications().get(0);
+		Assert.assertNotNull(streamMetrics);
 		Assert.assertEquals("http", application.getName());
 		Instance instance = application.getInstances().get(0);
 		Assert.assertEquals("foo", instance.getGuid());
@@ -74,9 +94,9 @@ public class MetricsAggregatorTests extends BaseCacheTests {
 		aggregator.receive(app2);
 
 		Assert.assertEquals(1, rawCache.estimatedSize());
-		stream = endpoint.fetchMetrics("").getBody().iterator().next();
-		application = stream.getApplications().get(0);
-		Assert.assertNotNull(stream);
+		streamMetrics = endpoint.fetchMetrics("").getBody().iterator().next();
+		application = streamMetrics.getApplications().get(0);
+		Assert.assertNotNull(streamMetrics);
 		Assert.assertEquals("http", application.getName());
 		instance = application.getInstances().get(0);
 		Assert.assertEquals("foo", instance.getGuid());
@@ -92,9 +112,9 @@ public class MetricsAggregatorTests extends BaseCacheTests {
 		aggregator.receive(app);
 
 		Assert.assertEquals(1, rawCache.estimatedSize());
-		Stream stream = endpoint.fetchMetrics("").getBody().iterator().next();
-		Application application = stream.getApplications().get(0);
-		Assert.assertNotNull(stream);
+		StreamMetrics streamMetrics = endpoint.fetchMetrics("").getBody().iterator().next();
+		Application application = streamMetrics.getApplications().get(0);
+		Assert.assertNotNull(streamMetrics);
 		Assert.assertEquals("http", application.getName());
 		Instance instance = application.getInstances().get(0);
 		Assert.assertEquals("foo", instance.getGuid());
@@ -103,9 +123,9 @@ public class MetricsAggregatorTests extends BaseCacheTests {
 		aggregator.receive(app2);
 
 		Assert.assertEquals(2, rawCache.estimatedSize());
-		stream = endpoint.fetchMetrics("").getBody().iterator().next();
-		application = stream.getApplications().get(0);
-		Assert.assertNotNull(stream);
+		streamMetrics = endpoint.fetchMetrics("").getBody().iterator().next();
+		application = streamMetrics.getApplications().get(0);
+		Assert.assertNotNull(streamMetrics);
 		Assert.assertEquals("http", application.getName());
 		Assert.assertEquals(2, application.getInstances().size());
 
@@ -122,21 +142,21 @@ public class MetricsAggregatorTests extends BaseCacheTests {
 		aggregator.receive(app);
 		aggregator.receive(app2);
 
-		Stream stream = endpoint.fetchMetrics("").getBody().iterator().next();
-		Application application = stream.getApplications().get(0);
+		StreamMetrics streamMetrics = endpoint.fetchMetrics("").getBody().iterator().next();
+		Application application = streamMetrics.getApplications().get(0);
 		Instance instance = application.getInstances().get(0);
 
 		Assert.assertEquals(2, rawCache.estimatedSize());
-		stream = endpoint.fetchMetrics("").getBody().iterator().next();
-		application = stream.getApplications().get(0);
-		Assert.assertNotNull(stream);
+		streamMetrics = endpoint.fetchMetrics("").getBody().iterator().next();
+		application = streamMetrics.getApplications().get(0);
+		Assert.assertNotNull(streamMetrics);
 		Assert.assertEquals("http", application.getName());
 		Assert.assertEquals(2, application.getInstances().size());
 		rawCache.invalidate("httpIngest.http.bar");
 		Thread.sleep(1000);
 		Assert.assertEquals(1, rawCache.estimatedSize());
-		stream = endpoint.fetchMetrics("").getBody().iterator().next();
-		application = stream.getApplications().get(0);
+		streamMetrics = endpoint.fetchMetrics("").getBody().iterator().next();
+		application = streamMetrics.getApplications().get(0);
 
 		Assert.assertEquals(1, application.getInstances().size());
 	}
@@ -154,8 +174,8 @@ public class MetricsAggregatorTests extends BaseCacheTests {
 		aggregator.receive(app2);
 
 		Assert.assertEquals(2, rawCache.estimatedSize());
-		Stream stream = endpoint.fetchMetrics("").getBody().iterator().next();
-		Assert.assertEquals(2, stream.getApplications().size());
+		StreamMetrics streamMetrics = endpoint.fetchMetrics("").getBody().iterator().next();
+		Assert.assertEquals(2, streamMetrics.getApplications().size());
 	}
 
 	@Test
@@ -170,7 +190,24 @@ public class MetricsAggregatorTests extends BaseCacheTests {
 		aggregator.receive(app);
 		aggregator.receive(app2);
 
-		Assert.assertEquals(2, endpoint.fetchMetrics("").getBody().size());
+		Assert.assertEquals(2, endpoint.fetchMetrics("").getBody().getContent().size());
+	}
+
+	@Test
+	public void filterByStream() throws Exception {
+		Cache<String, ApplicationMetrics> rawCache = Caffeine.newBuilder().build();
+		MetricsAggregator aggregator = new MetricsAggregator(rawCache);
+		MetricsCollectorEndpoint endpoint = new MetricsCollectorEndpoint(rawCache);
+
+		ApplicationMetrics app = createMetrics("httpIngest", "http", "foo", 0, 1.0, 0.0);
+		ApplicationMetrics app2 = createMetrics("woodchuck", "time", "bar", 0, 1.0, 0.0);
+		ApplicationMetrics app3 = createMetrics("twitter", "twitterstream", "bar", 0, 1.0, 0.0);
+
+		aggregator.receive(app);
+		aggregator.receive(app2);
+		aggregator.receive(app3);
+
+		Assert.assertEquals(2, endpoint.fetchMetrics("httpIngest,woodchuck").getBody().getContent().size());
 	}
 
 	private ApplicationMetrics createMetrics(String streamName, String applicationName, String appGuid, Integer index,


### PR DESCRIPTION
- Added support for HATEOAS standards. Fixes #4 
- Input destination defaults to `metrics` now. Fixes #18 
- Added key attribute to Instance class. Fixes #16 

[NOTE]: There's a change on the rest endpoint. Visiting the `/` resource would yield links to the metrics that are now under `/collector/metrics/streams`