### PR TITLE
Remove application.properties

### DIFF
--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/resources/application.properties
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.cloud.stream.bindings.input.destination=metrics


### PR DESCRIPTION
 - It may not be good to keep application.properties in the starter project
 - Also, the EnvironmentPostProcessor already takes care of it

Resolves #24