### PR TITLE
Adding aggregate metrics

### DIFF
--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Application.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Application.java
@@ -65,7 +65,7 @@ public class Application {
 		return getInstances().stream()
 				.map(instance -> instance.getMetrics())
 				.flatMap(metrics -> metrics.stream())
-				.filter(metric -> metric.getName().matches("integration\\.channel\\.(\\w*)\\.send.mean"))
+				.filter(metric -> metric.getName().matches("integration\\.channel\\.(\\w*)\\.send\\.mean"))
 				.collect(Collectors.groupingBy(Metric::getName,Collectors.summingDouble(Metric::getValue)))
 				.entrySet().stream()
 				.map(entry -> new Metric<Double>(entry.getKey(),entry.getValue(),new Date()))

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/ApplicationMetrics.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/ApplicationMetrics.java
@@ -45,13 +45,13 @@ public class ApplicationMetrics {
 
 	private String name;
 
-	private Collection<Metric> metrics;
+	private Collection<Metric<Double>> metrics;
 
 	private Map<String, Object> properties;
 
 	@JsonCreator
 	public ApplicationMetrics(@JsonProperty("name") String name,
-			@JsonProperty("metrics") Collection<Metric> metrics) {
+			@JsonProperty("metrics") Collection<Metric<Double>> metrics) {
 		this.name = name;
 		this.metrics = metrics;
 		this.createdTime = new Date();
@@ -65,11 +65,11 @@ public class ApplicationMetrics {
 		this.name = name;
 	}
 
-	public Collection<Metric> getMetrics() {
+	public Collection<Metric<Double>> getMetrics() {
 		return metrics;
 	}
 
-	public void setMetrics(Collection<Metric> metrics) {
+	public void setMetrics(Collection<Metric<Double>> metrics) {
 		this.metrics = metrics;
 	}
 

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Instance.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Instance.java
@@ -36,7 +36,7 @@ public class Instance {
 
 	private Map<String,Object> properties;
 
-	private Collection<Metric> metrics;
+	private Collection<Metric<Double>> metrics;
 
 	@JsonCreator
 	public Instance(String guid) {
@@ -77,11 +77,11 @@ public class Instance {
 	}
 
 
-	public Collection<Metric> getMetrics() {
+	public Collection<Metric<Double>> getMetrics() {
 		return metrics;
 	}
 
-	public void setMetrics(Collection<Metric> metrics) {
+	public void setMetrics(Collection<Metric<Double>> metrics) {
 		this.metrics = metrics;
 	}
 

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/services/ApplicationMetricsService.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/services/ApplicationMetricsService.java
@@ -166,7 +166,7 @@ public class ApplicationMetricsService {
 	private List<Metric<Double>> computeRate(List<ApplicationMetrics> applicationMetricsList) {
 		List<Metric<Double>> result = new ArrayList<>();
 		ApplicationMetrics applicationMetrics = applicationMetricsList.get(0);
-		for (Metric<?> metric : applicationMetrics.getMetrics()) {
+		for (Metric<Double> metric : applicationMetrics.getMetrics()) {
 			Matcher matcher = pattern.matcher(metric.getName());
 			if (matcher.matches()) {
 				Metric previous = applicationMetricsList.size() < 2 ? null
@@ -178,19 +178,19 @@ public class ApplicationMetricsService {
 		return result;
 	}
 
-	private Double delta(Metric current, Metric previous) {
+	private Double delta(Metric<Double> current, Metric<Double> previous) {
 		if (previous == null) {
 			return 0.0;
 		}
 		else {
-			return ((YANUtils.toDouble(current.getValue()) - YANUtils.toDouble(previous.getValue()))
-					/ (current.getTimestamp().getTime() - previous.getTimestamp().getTime())) * 1000;
+			return (current.getValue() - previous.getValue())
+					/ (current.getTimestamp().getTime() - previous.getTimestamp().getTime()) * 1000;
 		}
 	}
 
-	private Metric<?> findMetric(Collection<Metric> metrics, String name) {
-		Metric<?> result = null;
-		Optional<Metric> optinal = metrics.stream().filter(metric -> metric.getName().equals(name)).findFirst();
+	private Metric<Double> findMetric(Collection<Metric<Double>> metrics, String name) {
+		Metric<Double> result = null;
+		Optional<Metric<Double>> optinal = metrics.stream().filter(metric -> metric.getName().equals(name)).findFirst();
 		if (optinal.isPresent()) {
 			result = optinal.get();
 		}

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/support/MetricJsonSerializer.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/support/MetricJsonSerializer.java
@@ -53,7 +53,7 @@ public class MetricJsonSerializer {
 		public void serialize(Metric metric, JsonGenerator json, SerializerProvider serializerProvider) throws IOException {
 			json.writeStartObject();
 			json.writeStringField("name",metric.getName());
-			json.writeNumberField("value",metric.getValue().doubleValue());
+			json.writeNumberField("value",Double.valueOf(String.format("%.2f",metric.getValue().doubleValue())));
 			json.writeStringField("timestamp",df.get().format(metric.getTimestamp()));
 			json.writeEndObject();
 		}

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/utils/YANUtils.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/utils/YANUtils.java
@@ -29,21 +29,6 @@ public class YANUtils {
 		return targetClass.isInstance(candidate) ? Optional.of(targetClass.cast(candidate)) : Optional.empty();
 	}
 
-	public static Double toDouble(Object value){
-		Double result = 0.0;
-
-		if(value == null){
-			return result;
-		}
-		String stringVal = value.toString();
-		try{
-			result = Double.valueOf(stringVal);
-		}catch (NumberFormatException e){
-		}
-
-		return result;
-	}
-
 	public static Integer toInteger(Object value){
 		Integer result = 0;
 


### PR DESCRIPTION
Fixes #28 

- Added an aggregateMetrics attribute to the `Application` class
- Changed `Metric<?>` to be `Metric<Double>` across the entire project, we were already reading as double anyways, this simplified a lot of casting and issues with lambdas