### PR TITLE
Add SCSt 2.0 and Micrometer compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.springframework.cloud</groupId>
     <artifactId>spring-cloud-dataflow-metrics-collector-build</artifactId>
-    <version>1.0.1.BUILD-SNAPSHOT</version>
+    <version>2.0.0.BUILD-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.springframework.cloud.stream.app</groupId>
         <artifactId>app-starters-build</artifactId>
-        <version>1.2.0.RELEASE</version>
+        <version>2.0.0.BUILD-SNAPSHOT</version>
     </parent>
 
     <modules>
@@ -24,7 +24,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dataflow-metrics-collector-dependencies</artifactId>
-                <version>1.0.1.BUILD-SNAPSHOT</version>
+                <version>2.0.0.BUILD-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/spring-cloud-dataflow-metrics-collector-dependencies/pom.xml
+++ b/spring-cloud-dataflow-metrics-collector-dependencies/pom.xml
@@ -3,7 +3,7 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-dataflow-metrics-collector-dependencies</artifactId>
-	<version>1.0.1.BUILD-SNAPSHOT</version>
+	<version>2.0.0.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>metrics-collector-dependencies</name>
 	<description>Spring Cloud Data Flow Metrics Collector App Dependencies</description>
@@ -11,7 +11,7 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>1.3.1.RELEASE</version>
+		<version>2.0.0.BUILD-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 
@@ -20,7 +20,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-dataflow-metrics-collector</artifactId>
-				<version>1.0.1.BUILD-SNAPSHOT</version>
+				<version>2.0.0.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>com.github.ben-manes.caffeine</groupId>
@@ -30,7 +30,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-hateoas</artifactId>
-				<version>1.5.2.RELEASE</version>
+				<version>2.0.1.RELEASE</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-starter-dataflow-metrics-collector/pom.xml
+++ b/spring-cloud-starter-dataflow-metrics-collector/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dataflow-metrics-collector-build</artifactId>
-        <version>1.0.1.BUILD-SNAPSHOT</version>
+        <version>2.0.0.BUILD-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricCollectorProperties.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricCollectorProperties.java
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties(prefix = "spring.cloud.dataflow.metrics.collector")
 public class MetricCollectorProperties {
-	private Integer evictionTimeout = 30;
+	private Integer evictionTimeout = 70;
 
 	public Integer getEvictionTimeout() {
 		return evictionTimeout;

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricsAggregator.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricsAggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,41 +16,119 @@
 
 package org.springframework.cloud.dataflow.metrics.collector;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.cloud.dataflow.metrics.collector.model.ApplicationMetrics;
+import org.springframework.cloud.dataflow.metrics.collector.model.Metric;
+import org.springframework.cloud.dataflow.metrics.collector.model.MicrometerMetric;
 import org.springframework.cloud.dataflow.metrics.collector.services.ApplicationMetricsService;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 /**
  * Adds the incoming {@link ApplicationMetrics} payload into the backend store
  * @author Vinicius Carvalho
+ * @author Christian Tzolov
  */
 @Component
 public class MetricsAggregator {
+	private Logger logger = LoggerFactory.getLogger(MetricsAggregator.class);
 
+	private ObjectMapper mapper;
 	private ApplicationMetricsService service;
 
-	private Logger logger = LoggerFactory.getLogger(MetricsAggregator.class);
 
 	public MetricsAggregator(ApplicationMetricsService service) {
 		this.service = service;
+		this.mapper = new ObjectMapper();
 	}
 
+	private final static class Metric1TypeReference extends TypeReference<ApplicationMetrics<Metric<Number>>> {}
+
+	private final static class Metric2TypeReference extends TypeReference<ApplicationMetrics<MicrometerMetric<Number>>> {}
+
 	@StreamListener(Sink.INPUT)
-	public void receive(ApplicationMetrics metrics) {
+	public void receive(String metrics) {
+
+		ApplicationMetrics<Metric<Double>> applicationMetrics;
+		try {
+			// Use the "spring.integration.send" metric name as a version discriminator for old and new metrics
+			if (StringUtils.hasText(metrics) && metrics.contains("spring.integration.send")) {
+				ApplicationMetrics<MicrometerMetric<Number>> applicationMetrics2 = mapper.readValue(metrics, new Metric2TypeReference());
+				applicationMetrics = convertMetric2ToMetric(applicationMetrics2);
+				applicationMetrics.getProperties().put(ApplicationMetrics.STREAM_METRICS_VERSION, ApplicationMetrics.METRICS_VERSION_2);
+			}
+			else {
+				applicationMetrics = mapper.readValue(metrics, new Metric1TypeReference());
+				applicationMetrics.getProperties().put(ApplicationMetrics.STREAM_METRICS_VERSION, ApplicationMetrics.METRICS_VERSION_1);
+			}
+
+			this.processApplicationMetrics(applicationMetrics);
+		}
+		catch (IOException e) {
+			logger.warn("Invalid metrics Json", e);
+		}
+
+	}
+
+	/**
+	 * Converts the new Micrometer metrics into the previous {@link Metric}
+	 * format (e.g. to the Spring Boot 1.x actuator metrics)
+	 * Only the successful Spring Integration channel metrics are filtered in. All other metrics are discarded!
+	 * @param applicationMetrics2 {@link ApplicationMetrics} with Micrometer Metrics collection
+	 * @return Returns {@link ApplicationMetrics} with SpringBoot1.5's Metric collection.
+	 */
+	private ApplicationMetrics<Metric<Double>> convertMetric2ToMetric(ApplicationMetrics<MicrometerMetric<Number>> applicationMetrics2) {
+		List<Metric<Double>> metrics = applicationMetrics2.getMetrics().stream()
+				.filter(metric -> metric.getId().getName().matches("spring\\.integration\\.send"))
+				.filter(metric -> metric.getId().getTag("type").equals("channel"))
+				.filter(metric -> metric.getId().getTag("result").equals("success"))
+				.map(m2 -> new Metric<>(
+						generateOldMetricName(m2),
+						m2.getCount().doubleValue() / (applicationMetrics2.getInterval() / 1000), // normalize rate
+						m2.getTimestamp()))
+				.collect(Collectors.toList());
+		ApplicationMetrics<Metric<Double>> applicationMetrics = new ApplicationMetrics(applicationMetrics2.getName(), metrics);
+		applicationMetrics.setCreatedTime(applicationMetrics2.getCreatedTime());
+		applicationMetrics.setProperties(applicationMetrics2.getProperties());
+		return applicationMetrics;
+	}
+
+	/**
+	 * Build an hierarchical Metric Ver.1 name from the the multi-dimension (e.g. multi-tag) micrometer Metric
+	 * @param metric2 Micrometer based metrics
+	 * @return Returns an hierarchical name compatible with the Metric ver.1 name convention.
+	 */
+	private String generateOldMetricName(MicrometerMetric<Number> metric2) {
+		String oldMetricName = metric2.getId().getName();
+		if (metric2.getId().getName().startsWith("spring.integration.")) {
+			String channelName = metric2.getId().getTag("name");
+			String metricResult = metric2.getId().getTag("result");
+			String successSuffix = "success".equals(metricResult) ? "" : "." + metricResult;
+			oldMetricName = "integration.channel." + channelName + ".send.mean" + successSuffix;
+		}
+		return oldMetricName;
+	}
+
+	private void processApplicationMetrics(ApplicationMetrics<Metric<Double>> metrics) {
 		if (metrics.getProperties().get(ApplicationMetrics.APPLICATION_GUID) != null
 				&& metrics.getProperties().get(ApplicationMetrics.APPLICATION_NAME) != null
 				&& metrics.getProperties().get(ApplicationMetrics.STREAM_NAME) != null) {
 			this.service.add(metrics);
-		}else{
-			if(logger.isDebugEnabled()){
-				logger.debug("Metric : {} is missing key properties and will not be consumed by the collector",metrics.getName());
+		}
+		else {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Metric : {} is missing key properties and will not be consumed by the collector", metrics.getName());
 			}
 		}
 	}
-
 }

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricsCollectorConfiguration.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricsCollectorConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.dataflow.metrics.collector.endpoint.MetricsCollectorEndpoint;
 import org.springframework.cloud.dataflow.metrics.collector.endpoint.RootEndpoint;
 import org.springframework.cloud.dataflow.metrics.collector.model.ApplicationMetrics;
+import org.springframework.cloud.dataflow.metrics.collector.model.Metric;
 import org.springframework.cloud.dataflow.metrics.collector.services.ApplicationMetricsService;
 import org.springframework.cloud.dataflow.metrics.collector.support.CaffeineHealthIndicator;
 import org.springframework.cloud.dataflow.metrics.collector.support.MetricJsonSerializer;
@@ -39,6 +40,7 @@ import org.springframework.hateoas.EntityLinks;
 /**
  * @author Mark Pollack
  * @author Vinicius Carvalho
+ * @author Christian Tzolov
  */
 @Configuration
 @EnableBinding(Sink.class)
@@ -54,14 +56,14 @@ public class MetricsCollectorConfiguration {
 	}
 
 	@Bean
-	public Cache<String, LinkedList<ApplicationMetrics>> metricsStorage() {
-		return Caffeine.<String, ApplicationMetrics> newBuilder()
+	public Cache<String, LinkedList<ApplicationMetrics<Metric<Double>>>> metricsStorage() {
+		return Caffeine.<String, ApplicationMetrics<Metric<Double>>>newBuilder()
 				.expireAfterWrite(properties.getEvictionTimeout(), TimeUnit.SECONDS).recordStats().build();
 	}
 
 	@Bean
 	public ApplicationMetricsService applicationMetricsService(
-			Cache<String, LinkedList<ApplicationMetrics>> metricsStorage) throws Exception {
+			Cache<String, LinkedList<ApplicationMetrics<Metric<Double>>>> metricsStorage) {
 		return new ApplicationMetricsService(metricsStorage);
 	}
 
@@ -82,7 +84,7 @@ public class MetricsCollectorConfiguration {
 
 	@Bean
 	public CaffeineHealthIndicator caffeineHealthIndicator(
-			Cache<String, LinkedList<ApplicationMetrics>> metricsStorage) {
+			Cache<String, LinkedList<ApplicationMetrics<Metric<Double>>>> metricsStorage) {
 		return new CaffeineHealthIndicator(metricsStorage);
 	}
 }

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/MetricsCollectorEndpoint.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/MetricsCollectorEndpoint.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.dataflow.metrics.collector.endpoint;
 
 import java.util.Collection;
-import java.util.regex.Pattern;
 
 import org.springframework.cloud.dataflow.metrics.collector.model.StreamMetrics;
 import org.springframework.cloud.dataflow.metrics.collector.services.ApplicationMetricsService;
@@ -41,8 +40,6 @@ import org.springframework.web.bind.annotation.RestController;
 @ExposesResourceFor(StreamMetrics.class)
 public class MetricsCollectorEndpoint {
 
-	private final Pattern pattern = Pattern.compile("integration\\.channel\\.(\\w*)\\.sendCount");
-
 	private ApplicationMetricsService service;
 
 	public MetricsCollectorEndpoint(ApplicationMetricsService service) {
@@ -61,7 +58,7 @@ public class MetricsCollectorEndpoint {
 		PagedResources<StreamMetrics> pagedResources = new PagedResources<>(entries, pageMetadata,
 				ControllerLinkBuilder.linkTo(MetricsCollectorEndpoint.class).withRel(Link.REL_SELF));
 
-		return new ResponseEntity<PagedResources<StreamMetrics>>(pagedResources, HttpStatus.OK);
+		return new ResponseEntity<>(pagedResources, HttpStatus.OK);
 	}
 
 }

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Application.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Application.java
@@ -24,8 +24,6 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
-import org.springframework.boot.actuate.metrics.Metric;
-
 /**
  * @author Vinicius Carvalho
  */

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/ApplicationMetrics.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/ApplicationMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,15 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import org.springframework.boot.actuate.metrics.Metric;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * @author Vinicius Carvalho
+ * @author Oleg Zhurakousky
+ * @author Christian Tzolov
  */
-public class ApplicationMetrics {
+@JsonPropertyOrder({ "name", "createdTime", "properties", "metrics" })
+public class ApplicationMetrics<T> {
 
 	public static final String STREAM_NAME = "spring.cloud.dataflow.stream.name";
 	public static final String APPLICATION_NAME = "spring.cloud.dataflow.stream.app.label";
@@ -38,19 +40,25 @@ public class ApplicationMetrics {
 	public static final String APPLICATION_GUID = "spring.cloud.application.guid";
 	public static final String INSTANCE_INDEX = "spring.application.index";
 	public static final String APPLICATION_METRICS_JSON = "application/vnd.spring.cloud.stream.metrics.v1+json";
+	public static final String STREAM_METRICS_VERSION = "spring.cloud.dataflow.stream.metrics.version";
+
+	public static final String METRICS_VERSION_1 = "1.0";
+	public static final String METRICS_VERSION_2 = "2.0";
+
 
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
-	private final Date createdTime;
+	private Date createdTime;
 
 	private String name;
 
-	private Collection<Metric<Double>> metrics;
+	private Collection<T> metrics;
+
+	private long interval = 1000; //[ms]
 
 	private Map<String, Object> properties;
 
 	@JsonCreator
-	public ApplicationMetrics(@JsonProperty("name") String name,
-			@JsonProperty("metrics") Collection<Metric<Double>> metrics) {
+	public ApplicationMetrics(@JsonProperty("name") String name, @JsonProperty("metrics") Collection<T> metrics) {
 		this.name = name;
 		this.metrics = metrics;
 		this.createdTime = new Date();
@@ -64,16 +72,20 @@ public class ApplicationMetrics {
 		this.name = name;
 	}
 
-	public Collection<Metric<Double>> getMetrics() {
+	public Collection<T> getMetrics() {
 		return metrics;
 	}
 
-	public void setMetrics(Collection<Metric<Double>> metrics) {
+	public void setMetrics(Collection<T> metrics) {
 		this.metrics = metrics;
 	}
 
 	public Date getCreatedTime() {
 		return createdTime;
+	}
+
+	public void setCreatedTime(Date createdTime) {
+		this.createdTime = createdTime;
 	}
 
 	public Map<String, Object> getProperties() {
@@ -82,6 +94,14 @@ public class ApplicationMetrics {
 
 	public void setProperties(Map<String, Object> properties) {
 		this.properties = properties;
+	}
+
+	public long getInterval() {
+		return interval;
+	}
+
+	public void setInterval(long interval) {
+		this.interval = interval;
 	}
 
 	@Override
@@ -100,5 +120,4 @@ public class ApplicationMetrics {
 	public int hashCode() {
 		return name != null ? name.hashCode() : 0;
 	}
-
 }

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Instance.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Instance.java
@@ -21,8 +21,6 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
-import org.springframework.boot.actuate.metrics.Metric;
-
 /**
  * @author Vinicius Carvalho
  */

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Metric.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Metric.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.metrics.collector.model;
+
+import java.util.Date;
+
+import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
+
+/**
+ * Immutable class that can be used to hold any arbitrary system measurement value (a
+ * named numeric value with a timestamp). For example a metric might record the number of
+ * active connections to a server, or the temperature of a meeting room.
+ *
+ * @param <T> the value type
+ * @author Dave Syer
+ */
+public class Metric<T extends Number> {
+
+	private String name;
+
+	private T value;
+
+	private Date timestamp;
+
+	public Metric() {}
+
+	/**
+	 * Create a new {@link Metric} instance for the current time.
+	 * @param name the name of the metric
+	 * @param value the value of the metric
+	 */
+	public Metric(String name, T value) {
+		this(name, value, new Date());
+	}
+
+	/**
+	 * Create a new {@link Metric} instance.
+	 * @param name the name of the metric
+	 * @param value the value of the metric
+	 * @param timestamp the timestamp for the metric
+	 */
+	public Metric(String name, T value, Date timestamp) {
+		Assert.notNull(name, "Name must not be null");
+		this.name = name;
+		this.value = value;
+		this.timestamp = timestamp;
+	}
+
+	/**
+	 * Returns the name of the metric.
+	 * @return the name
+	 */
+	public String getName() {
+		return this.name;
+	}
+
+	/**
+	 * Returns the value of the metric.
+	 * @return the value
+	 */
+	public T getValue() {
+		return this.value;
+	}
+
+	public Date getTimestamp() {
+		return this.timestamp;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setTimestamp(Date timestamp) {
+		this.timestamp = timestamp;
+	}
+
+	public void setValue(T value) {
+		this.value = value;
+	}
+
+	@Override
+	public String toString() {
+		return "Metric [name=" + this.name + ", value=" + this.value + ", timestamp="
+				+ this.timestamp + "]";
+	}
+
+	/**
+	 * Create a new {@link Metric} with an incremented value.
+	 * @param amount the amount that the new metric will differ from this one
+	 * @return a new {@link Metric} instance
+	 */
+	public Metric<Long> increment(int amount) {
+		return new Metric<Long>(this.getName(),
+				Long.valueOf(this.getValue().longValue() + amount));
+	}
+
+	/**
+	 * Create a new {@link Metric} with a different value.
+	 * @param <S> the metric value type
+	 * @param value the value of the new metric
+	 * @return a new {@link Metric} instance
+	 */
+	public <S extends Number> Metric<S> set(S value) {
+		return new Metric<S>(this.getName(), value);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ObjectUtils.nullSafeHashCode(this.name);
+		result = prime * result + ObjectUtils.nullSafeHashCode(this.timestamp);
+		result = prime * result + ObjectUtils.nullSafeHashCode(this.value);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (obj instanceof Metric) {
+			Metric<?> other = (Metric<?>) obj;
+			boolean rtn = true;
+			rtn = rtn && ObjectUtils.nullSafeEquals(this.name, other.name);
+			rtn = rtn && ObjectUtils.nullSafeEquals(this.timestamp, other.timestamp);
+			rtn = rtn && ObjectUtils.nullSafeEquals(this.value, other.value);
+			return rtn;
+		}
+		return super.equals(obj);
+	}
+
+}

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/MicrometerMetric.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/MicrometerMetric.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.metrics.collector.model;
+
+import java.util.Date;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import io.micrometer.core.lang.Nullable;
+
+/**
+ * Immutable class that wraps the micrometer's {@link HistogramSnapshot}.
+ *
+ * @param <T> the value of type {@link Number}
+ *
+ * @author Oleg Zhurakousky
+ * @author Christian Tzolov
+ */
+@JsonPropertyOrder({ "id", "timestamp", "sum", "count", "mean", "upper", "total" })
+public class MicrometerMetric<T extends Number> {
+
+	private Date timestamp;
+
+	private Id id;
+
+	private Number sum = 0d;
+
+	private Number count = 0d;
+
+	private Number mean = 0d;
+
+	private Number upper = 0d;
+
+	private Number total = 0d;
+
+	public static class Tag {
+		private String key;
+
+		private String value;
+
+		public String getKey() {
+			return key;
+		}
+
+		public void setKey(String key) {
+			this.key = key;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		public void setValue(String value) {
+			this.value = value;
+		}
+	}
+
+	public static class Id {
+		private String name;
+
+		private List<Tag> tags;
+
+		private Meter.Type type;
+
+		@Nullable
+		private String description;
+
+		@Nullable
+		private String baseUnit;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public List<Tag> getTags() {
+			return tags;
+		}
+
+		public void setTags(List<Tag> tags) {
+			this.tags = tags;
+		}
+
+		public Meter.Type getType() {
+			return type;
+		}
+
+		public void setType(Meter.Type type) {
+			this.type = type;
+		}
+
+		public String getDescription() {
+			return description;
+		}
+
+		public String getBaseUnit() {
+			return baseUnit;
+		}
+
+		public void setBaseUnit(String baseUnit) {
+			this.baseUnit = baseUnit;
+		}
+
+		public String getTag(String key) {
+			for (Tag tag : tags) {
+				if (tag.getKey().equals(key))
+					return tag.getValue();
+			}
+			return null;
+		}
+	}
+
+	public Id getId() {
+		return this.id;
+	}
+
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "UTC")
+	public Date getTimestamp() {
+		return this.timestamp;
+	}
+
+	public Number getSum() {
+		return sum;
+	}
+
+	public Number getCount() {
+		return count;
+	}
+
+	public Number getMean() {
+		return mean;
+	}
+
+	public Number getUpper() {
+		return upper;
+	}
+
+	public Number getTotal() {
+		return total;
+	}
+
+
+	public void setTimestamp(Date timestamp) {
+		this.timestamp = timestamp;
+	}
+
+	public void setId(Id id) {
+		this.id = id;
+	}
+
+	public void setSum(Number sum) {
+		this.sum = sum;
+	}
+
+	public void setCount(Number count) {
+		this.count = count;
+	}
+
+	public void setMean(Number mean) {
+		this.mean = mean;
+	}
+
+	public void setUpper(Number upper) {
+		this.upper = upper;
+	}
+
+	public void setTotal(Number total) {
+		this.total = total;
+	}
+
+	@Override
+	public String toString() {
+		return "MicrometerMetric [id=" + this.id +
+				", sum=" + this.sum +
+				", count=" + this.count +
+				", mean=" + this.mean +
+				", upper=" + this.upper +
+				", total=" + this.total +
+				", timestamp=" + this.timestamp + "]";
+	}
+}

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/support/MetricJsonSerializer.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/support/MetricJsonSerializer.java
@@ -35,8 +35,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
-import org.springframework.boot.actuate.metrics.Metric;
+
 import org.springframework.boot.jackson.JsonComponent;
+import org.springframework.cloud.dataflow.metrics.collector.model.Metric;
 
 /**
  * @author Vinicius Carvalho

--- a/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/MetricJsonSerializerTests.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/MetricJsonSerializerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,8 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.junit.Assert;
 import org.junit.Test;
 
-import org.springframework.boot.actuate.metrics.Metric;
+
+import org.springframework.cloud.dataflow.metrics.collector.model.Metric;
 import org.springframework.cloud.dataflow.metrics.collector.support.MetricJsonSerializer;
 
 /**


### PR DESCRIPTION
Resolves #51
Resolves #55

- Extend MetricAggregator to accept and dispatch Metrics coming from SpringBoot 1.x apps as well as MicrometerMetrics from SpringBoot2/SCSt2 apps.
  - Uses the spring.integration.send string as metrics type discriminator.
- MetricAggregator converts on the fly the received MicrometerMetrics classes into Metrics such.
  - The MicrometerMetrics multidimensional (e.g. multi-tag) identity is converted into hierarchical Metrics name convention.
  - Only the spring.integration.x MicrometerMetrics metrics are filtered in.
- The MicrometerMetrics have the rates precomputed. Therefore the ApplicationMetricsService rate computation logic is applied only to the Metrics (1.x) metrics.
- New compute logic for the Application#getAggregateMetrics
- Support for mixed SCSt1.x and SCSt2.x app metrics
- Fix the Metrics 1.x tests and add MicrometerMetric tests