### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,10 @@
 == Spring Cloud Data Flow Metrics Collector
 
-The metrics collector is a companion application to the http://cloud.spring.io/spring-cloud-dataflow/[Spring Cloud Data Flow] server.
+The metrics collector is a companion application to the https://cloud.spring.io/spring-cloud-dataflow/[Spring Cloud Data Flow] server.
 
-It collects metrics emitted by http://cloud.spring.io/spring-cloud-stream/[Spring Cloud Stream] apps, and groups them together around the stream definition that dataflow used to deploy them.
+It collects metrics emitted by https://cloud.spring.io/spring-cloud-stream/[Spring Cloud Stream] apps, and groups them together around the stream definition that dataflow used to deploy them.
 
-All of the OOB http://cloud.spring.io/spring-cloud-stream-app-starters/[Spring Cloud App Starters] currently have the metrics emitter module already bundled on it.
+All of the OOB https://cloud.spring.io/spring-cloud-stream-app-starters/[Spring Cloud App Starters] currently have the metrics emitter module already bundled on it.
 You can enable metric emission by setting the destination name for metrics binding, e.g. `spring.cloud.stream.bindings.applicationMetrics.destination=<DESTINATION_NAME>`
 
 Starting with Spring Cloud Stream 2.0, the default metrics support has been switched to use https://micrometer.io/[Micrometer]. See https://docs.spring.io/spring-cloud-stream/docs/Elmhurst.RELEASE/reference/htmlsingle/#spring-cloud-stream-overview-metrics-emitter[Metrics Emitter] for more details.
@@ -17,8 +17,8 @@ The metrics collector 2.x support collecting metrics from both Spring Cloud Stre
 [width="40%",frame="topbot",options="header,footer"]
 |======================
 |Uber Jar |Http Link |Docker Hub Link
-|metrics-collector-rabbit| http://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-rabbit/2.0.0.RELEASE/metrics-collector-rabbit-2.0.0.RELEASE.jar | https://hub.docker.com/r/springcloud/metrics-collector-rabbit/tags/ [docker pull metrics-collector-rabbit:2.0.0.RELEASE]
-|metrics-collector-kafka| http://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-kafka/2.0.0.RELEASE/metrics-collector-kafka-2.0.0.RELEASE.jar | https://hub.docker.com/r/springcloud/metrics-collector-kafka/tags/ [docker pull metrics-collector-kafka:2.0.0.RELEASE]
+|metrics-collector-rabbit| https://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-rabbit/2.0.0.RELEASE/metrics-collector-rabbit-2.0.0.RELEASE.jar | https://hub.docker.com/r/springcloud/metrics-collector-rabbit/tags/ [docker pull metrics-collector-rabbit:2.0.0.RELEASE]
+|metrics-collector-kafka| https://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-kafka/2.0.0.RELEASE/metrics-collector-kafka-2.0.0.RELEASE.jar | https://hub.docker.com/r/springcloud/metrics-collector-kafka/tags/ [docker pull metrics-collector-kafka:2.0.0.RELEASE]
 |======================
 
 ## Downloadable Links for Latest 1.0 GA Releases for Metrics Collector Uber Jars and Docker Images
@@ -26,9 +26,9 @@ The metrics collector 2.x support collecting metrics from both Spring Cloud Stre
 [width="40%",frame="topbot",options="header,footer"]
 |======================
 |Uber Jar |Http Link |Docker Hub Link
-|metrics-collector-rabbit| http://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-rabbit/1.0.0.RELEASE/metrics-collector-rabbit-1.0.0.RELEASE.jar| https://hub.docker.com/r/springcloud/metrics-collector-rabbit/tags/ [docker pull metrics-collector-rabbit:1.0.0.RELEASE]
-|metrics-collector-kafka-09| http://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-kafka-09/1.0.0.RELEASE/metrics-collector-kafka-09-1.0.0.RELEASE.jar | https://hub.docker.com/r/springcloud/metrics-collector-kafka-09/tags/ [docker pull metrics-collector-kafka-09:1.0.0.RELEASE]
-|metrics-collector-kafka-10| http://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-kafka-10/1.0.0.RELEASE/metrics-collector-kafka-10-1.0.0.RELEASE.jar | https://hub.docker.com/r/springcloud/metrics-collector-kafka-10/tags/ [docker pull metrics-collector-kafka-10:1.0.0.RELEASE]
+|metrics-collector-rabbit| https://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-rabbit/1.0.0.RELEASE/metrics-collector-rabbit-1.0.0.RELEASE.jar| https://hub.docker.com/r/springcloud/metrics-collector-rabbit/tags/ [docker pull metrics-collector-rabbit:1.0.0.RELEASE]
+|metrics-collector-kafka-09| https://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-kafka-09/1.0.0.RELEASE/metrics-collector-kafka-09-1.0.0.RELEASE.jar | https://hub.docker.com/r/springcloud/metrics-collector-kafka-09/tags/ [docker pull metrics-collector-kafka-09:1.0.0.RELEASE]
+|metrics-collector-kafka-10| https://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-kafka-10/1.0.0.RELEASE/metrics-collector-kafka-10-1.0.0.RELEASE.jar | https://hub.docker.com/r/springcloud/metrics-collector-kafka-10/tags/ [docker pull metrics-collector-kafka-10:1.0.0.RELEASE]
 |======================
 
 ## Downloadable Links for Latest 2.0 Snapshots for Metrics Collector Uber Jars and Docker Images
@@ -36,8 +36,8 @@ The metrics collector 2.x support collecting metrics from both Spring Cloud Stre
 [width="40%",frame="topbot",options="header,footer"]
 |======================
 |Uber Jar |Http Link |Docker Hub Link
-|metrics-collector-rabbit| http://repo.spring.io/libs-snapshot-local/org/springframework/cloud/metrics-collector-rabbit/2.0.0.BUILD-SNAPSHOT/metrics-collector-rabbit-2.0.0.BUILD-SNAPSHOT.jar| https://hub.docker.com/r/springcloud/metrics-collector-rabbit/tags/ [docker pull metrics-collector-rabbit:2.0.0.BUILD-SNAPSHOT]
-|metrics-collector-kafka| http://repo.spring.io/libs-snapshot-local/org/springframework/cloud/metrics-collector-kafka/2.0.0.BUILD-SNAPSHOT/metrics-collector-kafka-2.0.0.BUILD-SNAPSHOT.jar | https://hub.docker.com/r/springcloud/metrics-collector-kafka/tags/ [docker pull metrics-collector-kafka:2.0.0.BUILD-SNAPSHOT]
+|metrics-collector-rabbit| https://repo.spring.io/libs-snapshot-local/org/springframework/cloud/metrics-collector-rabbit/2.0.0.BUILD-SNAPSHOT/metrics-collector-rabbit-2.0.0.BUILD-SNAPSHOT.jar| https://hub.docker.com/r/springcloud/metrics-collector-rabbit/tags/ [docker pull metrics-collector-rabbit:2.0.0.BUILD-SNAPSHOT]
+|metrics-collector-kafka| https://repo.spring.io/libs-snapshot-local/org/springframework/cloud/metrics-collector-kafka/2.0.0.BUILD-SNAPSHOT/metrics-collector-kafka-2.0.0.BUILD-SNAPSHOT.jar | https://hub.docker.com/r/springcloud/metrics-collector-kafka/tags/ [docker pull metrics-collector-kafka:2.0.0.BUILD-SNAPSHOT]
 |======================
 
 == Building
@@ -110,7 +110,7 @@ Server:
 java -jar spring-cloud-dataflow-server-local/target/spring-cloud-dataflow-server-local-1.5.0.BUILD-SNAPSHOT.jar --spring.cloud.dataflow.metrics.collector.uri=http://localhost:8080 --spring.cloud.dataflow.metrics.collector.username=spring --spring.cloud.dataflow.metrics.collector.password=cloud
 
 Register SCSt 1.x Apps:
-app import --uri http://bit.ly/Celsius-SR1-stream-applications-rabbit-maven
+app import --uri https://bit.ly/Celsius-SR1-stream-applications-rabbit-maven
 
 Stream:
 stream create --name foostream --definition "time | log"

--- a/docs/src/main/asciidoc/appendix-contributing.adoc
+++ b/docs/src/main/asciidoc/appendix-contributing.adoc
@@ -24,7 +24,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://github.com/spring-cloud/spring-cloud-build/blob/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -37,6 +37,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -8,11 +8,11 @@ Vinicius Carvalho, Marius Bogoevici; Mark Pollack; Janne Valkealahti
 :icons: font
 :hide-uri-scheme:
 
-:spring-cloud-dataflow-docs: http://docs.spring.io/spring-cloud-dataflow/docs/{project-version}/reference
-:spring-cloud-dataflow-docs-current: http://docs.spring.io/spring-cloud-dataflow/docs/current-SNAPSHOT/reference/html/
-:spring-cloud-stream-docs: http://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/index.html
+:spring-cloud-dataflow-docs: https://docs.spring.io/spring-cloud-dataflow/docs/{project-version}/reference
+:spring-cloud-dataflow-docs-current: https://docs.spring.io/spring-cloud-dataflow/docs/current-SNAPSHOT/reference/html/
+:spring-cloud-stream-docs: https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/index.html
 :github-repo: spring-cloud/spring-cloud-dataflow
-:github-code: http://github.com/{github-repo}
+:github-code: https://github.com/{github-repo}
 
 :dataflow-asciidoc: https://raw.githubusercontent.com/spring-cloud/spring-cloud-dataflow/master/spring-cloud-dataflow-docs/src/main/asciidoc
 

--- a/docs/src/main/docbook/xsl/common.xsl
+++ b/docs/src/main/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/docs/src/main/docbook/xsl/epub.xsl
+++ b/docs/src/main/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/docs/src/main/docbook/xsl/html.xsl
+++ b/docs/src/main/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>

--- a/docs/src/main/docbook/xsl/pdf.xsl
+++ b/docs/src/main/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:d="http://docbook.org/ns/docbook"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				xmlns:xlink='http://www.w3.org/1999/xlink'
 				xmlns:exsl="http://exslt.org/common"
 				exclude-result-prefixes="exsl xslthl d xlink"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 1 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://docs.spring.io/spring-cloud-dataflow/docs/current-SNAPSHOT/reference/html/ (404) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow/docs/current-SNAPSHOT/reference/html/ ([https](https://docs.spring.io/spring-cloud-dataflow/docs/current-SNAPSHOT/reference/html/) result 404).
* [ ] http://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-rabbit/1.0.0.RELEASE/metrics-collector-rabbit-1.0.0.RELEASE.jar| (404) with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-rabbit/1.0.0.RELEASE/metrics-collector-rabbit-1.0.0.RELEASE.jar| ([https](https://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-rabbit/1.0.0.RELEASE/metrics-collector-rabbit-1.0.0.RELEASE.jar|) result 404).
* [ ] http://repo.spring.io/libs-snapshot-local/org/springframework/cloud/metrics-collector-rabbit/2.0.0.BUILD-SNAPSHOT/metrics-collector-rabbit-2.0.0.BUILD-SNAPSHOT.jar| (404) with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot-local/org/springframework/cloud/metrics-collector-rabbit/2.0.0.BUILD-SNAPSHOT/metrics-collector-rabbit-2.0.0.BUILD-SNAPSHOT.jar| ([https](https://repo.spring.io/libs-snapshot-local/org/springframework/cloud/metrics-collector-rabbit/2.0.0.BUILD-SNAPSHOT/metrics-collector-rabbit-2.0.0.BUILD-SNAPSHOT.jar|) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-dataflow/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-dataflow/ ([https](https://cloud.spring.io/spring-cloud-dataflow/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-stream-app-starters/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-stream-app-starters/ ([https](https://cloud.spring.io/spring-cloud-stream-app-starters/) result 200).
* [ ] http://cloud.spring.io/spring-cloud-stream/ with 1 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-stream/ ([https](https://cloud.spring.io/spring-cloud-stream/) result 200).
* [ ] http://docs.spring.io/spring-cloud-dataflow/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-dataflow/docs/ ([https](https://docs.spring.io/spring-cloud-dataflow/docs/) result 200).
* [ ] http://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/index.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/index.html ([https](https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/index.html) result 200).
* [ ] http://github.com/ with 1 occurrences migrated to:  
  https://github.com/ ([https](https://github.com/) result 200).
* [ ] http://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-kafka-09/1.0.0.RELEASE/metrics-collector-kafka-09-1.0.0.RELEASE.jar with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-kafka-09/1.0.0.RELEASE/metrics-collector-kafka-09-1.0.0.RELEASE.jar ([https](https://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-kafka-09/1.0.0.RELEASE/metrics-collector-kafka-09-1.0.0.RELEASE.jar) result 200).
* [ ] http://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-kafka-10/1.0.0.RELEASE/metrics-collector-kafka-10-1.0.0.RELEASE.jar with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-kafka-10/1.0.0.RELEASE/metrics-collector-kafka-10-1.0.0.RELEASE.jar ([https](https://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-kafka-10/1.0.0.RELEASE/metrics-collector-kafka-10-1.0.0.RELEASE.jar) result 200).
* [ ] http://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-kafka/2.0.0.RELEASE/metrics-collector-kafka-2.0.0.RELEASE.jar with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-kafka/2.0.0.RELEASE/metrics-collector-kafka-2.0.0.RELEASE.jar ([https](https://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-kafka/2.0.0.RELEASE/metrics-collector-kafka-2.0.0.RELEASE.jar) result 200).
* [ ] http://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-rabbit/2.0.0.RELEASE/metrics-collector-rabbit-2.0.0.RELEASE.jar with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-rabbit/2.0.0.RELEASE/metrics-collector-rabbit-2.0.0.RELEASE.jar ([https](https://repo.spring.io/libs-release/org/springframework/cloud/metrics-collector-rabbit/2.0.0.RELEASE/metrics-collector-rabbit-2.0.0.RELEASE.jar) result 200).
* [ ] http://repo.spring.io/libs-snapshot-local/org/springframework/cloud/metrics-collector-kafka/2.0.0.BUILD-SNAPSHOT/metrics-collector-kafka-2.0.0.BUILD-SNAPSHOT.jar with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot-local/org/springframework/cloud/metrics-collector-kafka/2.0.0.BUILD-SNAPSHOT/metrics-collector-kafka-2.0.0.BUILD-SNAPSHOT.jar ([https](https://repo.spring.io/libs-snapshot-local/org/springframework/cloud/metrics-collector-kafka/2.0.0.BUILD-SNAPSHOT/metrics-collector-kafka-2.0.0.BUILD-SNAPSHOT.jar) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://bit.ly/Celsius-SR1-stream-applications-rabbit-maven with 1 occurrences migrated to:  
  https://bit.ly/Celsius-SR1-stream-applications-rabbit-maven ([https](https://bit.ly/Celsius-SR1-stream-applications-rabbit-maven) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 4 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://localhost:8080 with 1 occurrences
* http://localhost:9393/dashboard with 2 occurrences
* http://localhost:9393/dashboard/ with 1 occurrences
* http://maven.apache.org/POM/4.0.0 with 1 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 7 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences