### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/docs/src/main/docbook/xsl/common.xsl
+++ b/docs/src/main/docbook/xsl/common.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/docs/src/main/docbook/xsl/epub.xsl
+++ b/docs/src/main/docbook/xsl/epub.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/docs/src/main/docbook/xsl/html-multipage.xsl
+++ b/docs/src/main/docbook/xsl/html-multipage.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/docs/src/main/docbook/xsl/html-singlepage.xsl
+++ b/docs/src/main/docbook/xsl/html-singlepage.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/docs/src/main/docbook/xsl/html.xsl
+++ b/docs/src/main/docbook/xsl/html.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/docs/src/main/docbook/xsl/pdf.xsl
+++ b/docs/src/main/docbook/xsl/pdf.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricCollectorProperties.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricCollectorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricsAggregator.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricsAggregator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricsCollectorConfiguration.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/MetricsCollectorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/MetricsCollectorEndpoint.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/MetricsCollectorEndpoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/RootEndpoint.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/endpoint/RootEndpoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Application.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/ApplicationMetrics.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/ApplicationMetrics.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Instance.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Instance.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Metric.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/Metric.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/MicrometerMetric.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/MicrometerMetric.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/RootResource.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/RootResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/StreamMetrics.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/model/StreamMetrics.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/services/ApplicationMetricsService.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/services/ApplicationMetricsService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/support/ApplicationMetricsBindingPostProcessor.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/support/ApplicationMetricsBindingPostProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/support/CaffeineHealthIndicator.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/support/CaffeineHealthIndicator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/support/MetricJsonSerializer.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/support/MetricJsonSerializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/utils/YANUtils.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/main/java/org/springframework/cloud/dataflow/metrics/collector/utils/YANUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/BaseCacheTests.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/BaseCacheTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/CollectorApplication.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/CollectorApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/CollectorApplicationTests.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/CollectorApplicationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/MetricJsonSerializerTests.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/MetricJsonSerializerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/MetricsAggregatorTests.java
+++ b/spring-cloud-starter-dataflow-metrics-collector/src/test/java/org/springframework/cloud/dataflow/metrics/collector/MetricsAggregatorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 29 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).